### PR TITLE
feat: Adiciona testes de widget para telas de login e registro

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -196,10 +196,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -457,10 +457,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   web:
     dependency: transitive
     description:

--- a/test/screens/auth/login_screen_test.dart
+++ b/test/screens/auth/login_screen_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moodyr/screens/auth/login_screen.dart';
+import 'package:moodyr/widgets/custom_button.dart'; // Necessário para encontrar o CustomButton
+
+void main() {
+  // Helper para envolver o widget em teste com MaterialApp e Scaffold
+  Widget makeTestableWidget(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: child),
+    );
+  }
+
+  group('LoginScreen Widget Tests', () {
+    testWidgets('Campos vazios devem exibir mensagens de erro', (WidgetTester tester) async {
+      // Renderiza a LoginScreen
+      await tester.pumpWidget(makeTestableWidget(const LoginScreen()));
+
+      // Tenta submeter o formulário (clicar no botão Entrar)
+      // Primeiro, encontra o CustomButton. Pode ser necessário ajustar o Finder se houver mais de um.
+      final Finder loginButton = find.widgetWithText(CustomButton, 'Entrar');
+      expect(loginButton, findsOneWidget, reason: 'Botão "Entrar" não encontrado');
+      await tester.tap(loginButton);
+      await tester.pump(); // Reconstrói o widget após o tap para exibir erros
+
+      // Verifica as mensagens de erro
+      expect(find.text('E-mail Inválido'), findsOneWidget);
+      expect(find.text('Senha Inválida '), findsOneWidget);
+    });
+
+    testWidgets('E-mail inválido deve exibir mensagem de erro para e-mail', (WidgetTester tester) async {
+      await tester.pumpWidget(makeTestableWidget(const LoginScreen()));
+
+      // Encontra o campo de e-mail e insere um e-mail inválido
+      final emailField = find.widgetWithText(TextFormField, 'Email'); // Procura pelo labelText
+      expect(emailField, findsOneWidget, reason: 'Campo de texto "Email" não encontrado');
+      await tester.enterText(emailField, 'emailinvalido');
+      
+      // Encontra o campo de senha e insere uma senha qualquer (válida ou não, para isolar o teste do email)
+      final passwordField = find.widgetWithText(TextFormField, 'Senha');
+      expect(passwordField, findsOneWidget, reason: 'Campo de texto "Senha" não encontrado');
+      await tester.enterText(passwordField, 'Valida123'); // Senha válida para não interferir
+
+      // Toca no botão de login
+      final Finder loginButton = find.widgetWithText(CustomButton, 'Entrar');
+      expect(loginButton, findsOneWidget, reason: 'Botão "Entrar" não encontrado');
+      await tester.tap(loginButton);
+      await tester.pump();
+
+      // Verifica a mensagem de erro para o e-mail
+      expect(find.text('E-mail Inválido'), findsOneWidget);
+      // Garante que não há erro de senha, pois a senha inserida é válida
+      expect(find.text('Senha Inválida '), findsNothing);
+    });
+
+    testWidgets('Senha inválida deve exibir mensagem de erro para senha', (WidgetTester tester) async {
+      await tester.pumpWidget(makeTestableWidget(const LoginScreen()));
+
+      // E-mail válido
+      final emailField = find.widgetWithText(TextFormField, 'Email');
+      expect(emailField, findsOneWidget, reason: 'Campo de texto "Email" não encontrado');
+      await tester.enterText(emailField, 'valido@email.com');
+
+      // Senha inválida
+      final passwordField = find.widgetWithText(TextFormField, 'Senha');
+      expect(passwordField, findsOneWidget, reason: 'Campo de texto "Senha" não encontrado');
+      await tester.enterText(passwordField, 'curta');
+      
+      final Finder loginButton = find.widgetWithText(CustomButton, 'Entrar');
+      expect(loginButton, findsOneWidget, reason: 'Botão "Entrar" não encontrado');
+      await tester.tap(loginButton);
+      await tester.pump();
+
+      // Verifica a mensagem de erro para a senha
+      expect(find.text('Senha Inválida '), findsOneWidget);
+      // Garante que não há erro de email
+      expect(find.text('E-mail Inválido'), findsNothing);
+    });
+
+    testWidgets('Dados válidos não devem exibir mensagens de erro de validação', (WidgetTester tester) async {
+      await tester.pumpWidget(makeTestableWidget(const LoginScreen()));
+
+      // E-mail válido
+      final emailField = find.widgetWithText(TextFormField, 'Email');
+      expect(emailField, findsOneWidget, reason: 'Campo de texto "Email" não encontrado');
+      await tester.enterText(emailField, 'valido@email.com');
+
+      // Senha válida
+      final passwordField = find.widgetWithText(TextFormField, 'Senha');
+      expect(passwordField, findsOneWidget, reason: 'Campo de texto "Senha" não encontrado');
+      await tester.enterText(passwordField, 'ValidaSenha123');
+      
+      final Finder loginButton = find.widgetWithText(CustomButton, 'Entrar');
+      expect(loginButton, findsOneWidget, reason: 'Botão "Entrar" não encontrado');
+      await tester.tap(loginButton);
+      await tester.pump(); // pump para processar o tap
+
+      // Nenhuma mensagem de erro deve ser exibida para os validadores locais.
+      // O teste não verifica a lógica de login (chamada HTTP), apenas a validação do formulário.
+      expect(find.text('E-mail Inválido'), findsNothing);
+      expect(find.text('Senha Inválida '), findsNothing);
+
+      // Poderia verificar se o CircularProgressIndicator aparece, indicando que a validação passou
+      // e a lógica de login foi acionada.
+      // expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      // No entanto, para evitar que o teste dependa da lógica de rede, vamos manter focado na validação.
+    });
+  });
+}

--- a/test/screens/auth/register_screen_test.dart
+++ b/test/screens/auth/register_screen_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moodyr/screens/auth/register_screen.dart';
+import 'package:moodyr/widgets/custom_button.dart'; // Necessário para encontrar o CustomButton
+
+void main() {
+  // Helper para envolver o widget em teste com MaterialApp e Scaffold
+  Widget makeTestableWidget(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: child),
+    );
+  }
+
+  group('RegisterScreen Widget Tests', () {
+    testWidgets('Campos vazios devem exibir mensagens de erro', (WidgetTester tester) async {
+      await tester.pumpWidget(makeTestableWidget(const RegisterScreen()));
+
+      final Finder registerButton = find.widgetWithText(CustomButton, 'Registrar');
+      expect(registerButton, findsOneWidget, reason: 'Botão "Registrar" não encontrado');
+      await tester.tap(registerButton);
+      await tester.pump();
+
+      expect(find.text('Nome Inválido'), findsOneWidget);
+      expect(find.text('E-mail Inválido'), findsOneWidget);
+      // A mensagem exata para senha pode variar dependendo da implementação do validador
+      expect(find.textContaining('A senha deve ter pelo menos'), findsOneWidget); 
+      expect(find.text('Por favor, confirme sua senha'), findsOneWidget);
+    });
+
+    testWidgets('Nome inválido deve exibir mensagem de erro para nome', (WidgetTester tester) async {
+      await tester.pumpWidget(makeTestableWidget(const RegisterScreen()));
+
+      final nameField = find.widgetWithText(TextFormField, 'Nome');
+      expect(nameField, findsOneWidget, reason: 'Campo "Nome" não encontrado');
+      await tester.enterText(nameField, 'N0meComNumer0'); // Inválido
+
+      final emailField = find.widgetWithText(TextFormField, 'Email');
+      await tester.enterText(emailField, 'valido@email.com');
+      final passwordField = find.widgetWithText(TextFormField, 'Senha');
+      await tester.enterText(passwordField, 'Valida123!');
+      final confirmPasswordField = find.widgetWithText(TextFormField, 'Confirmar Senha');
+      await tester.enterText(confirmPasswordField, 'Valida123!');
+
+      final Finder registerButton = find.widgetWithText(CustomButton, 'Registrar');
+      await tester.tap(registerButton);
+      await tester.pump();
+
+      expect(find.text('Nome Inválido'), findsOneWidget);
+      expect(find.text('E-mail Inválido'), findsNothing);
+      expect(find.textContaining('A senha deve ter pelo menos'), findsNothing);
+      expect(find.text('As senhas não coincidem'), findsNothing);
+    });
+
+    testWidgets('E-mail inválido deve exibir mensagem de erro para e-mail', (WidgetTester tester) async {
+      await tester.pumpWidget(makeTestableWidget(const RegisterScreen()));
+
+      final nameField = find.widgetWithText(TextFormField, 'Nome');
+      await tester.enterText(nameField, 'Nome Valido');
+      final emailField = find.widgetWithText(TextFormField, 'Email');
+      await tester.enterText(emailField, 'emailinvalido'); // Inválido
+      final passwordField = find.widgetWithText(TextFormField, 'Senha');
+      await tester.enterText(passwordField, 'Valida123!');
+      final confirmPasswordField = find.widgetWithText(TextFormField, 'Confirmar Senha');
+      await tester.enterText(confirmPasswordField, 'Valida123!');
+
+      final Finder registerButton = find.widgetWithText(CustomButton, 'Registrar');
+      await tester.tap(registerButton);
+      await tester.pump();
+
+      expect(find.text('E-mail Inválido'), findsOneWidget);
+      expect(find.text('Nome Inválido'), findsNothing);
+      expect(find.textContaining('A senha deve ter pelo menos'), findsNothing);
+    });
+    
+    testWidgets('Senha inválida deve exibir mensagem de erro para senha', (WidgetTester tester) async {
+      await tester.pumpWidget(makeTestableWidget(const RegisterScreen()));
+
+      final nameField = find.widgetWithText(TextFormField, 'Nome');
+      await tester.enterText(nameField, 'Nome Valido');
+      final emailField = find.widgetWithText(TextFormField, 'Email');
+      await tester.enterText(emailField, 'valido@email.com');
+      final passwordField = find.widgetWithText(TextFormField, 'Senha');
+      await tester.enterText(passwordField, 'curta'); // Inválida
+      final confirmPasswordField = find.widgetWithText(TextFormField, 'Confirmar Senha');
+      await tester.enterText(confirmPasswordField, 'curta');
+
+
+      final Finder registerButton = find.widgetWithText(CustomButton, 'Registrar');
+      await tester.tap(registerButton);
+      await tester.pump();
+      
+      expect(find.textContaining('A senha deve ter pelo menos'), findsOneWidget);
+      expect(find.text('Nome Inválido'), findsNothing);
+      expect(find.text('E-mail Inválido'), findsNothing);
+    });
+
+    testWidgets('Senhas não coincidentes devem exibir mensagem de erro', (WidgetTester tester) async {
+      await tester.pumpWidget(makeTestableWidget(const RegisterScreen()));
+
+      final nameField = find.widgetWithText(TextFormField, 'Nome');
+      await tester.enterText(nameField, 'Nome Valido');
+      final emailField = find.widgetWithText(TextFormField, 'Email');
+      await tester.enterText(emailField, 'valido@email.com');
+      final passwordField = find.widgetWithText(TextFormField, 'Senha');
+      await tester.enterText(passwordField, 'Valida123!');
+      final confirmPasswordField = find.widgetWithText(TextFormField, 'Confirmar Senha');
+      await tester.enterText(confirmPasswordField, 'Diferente123!'); // Diferente
+
+      final Finder registerButton = find.widgetWithText(CustomButton, 'Registrar');
+      await tester.tap(registerButton);
+      await tester.pump();
+
+      expect(find.text('As senhas não coincidem'), findsOneWidget);
+      expect(find.text('Nome Inválido'), findsNothing);
+      expect(find.text('E-mail Inválido'), findsNothing);
+      expect(find.textContaining('A senha deve ter pelo menos'), findsNothing); // Assumindo que "Valida123!" é válida
+    });
+
+    testWidgets('Dados válidos não devem exibir mensagens de erro de validação', (WidgetTester tester) async {
+      await tester.pumpWidget(makeTestableWidget(const RegisterScreen()));
+
+      final nameField = find.widgetWithText(TextFormField, 'Nome');
+      await tester.enterText(nameField, 'Nome Valido');
+      final emailField = find.widgetWithText(TextFormField, 'Email');
+      await tester.enterText(emailField, 'valido@email.com');
+      final passwordField = find.widgetWithText(TextFormField, 'Senha');
+      await tester.enterText(passwordField, 'Valida123!');
+      final confirmPasswordField = find.widgetWithText(TextFormField, 'Confirmar Senha');
+      await tester.enterText(confirmPasswordField, 'Valida123!');
+      
+      final Finder registerButton = find.widgetWithText(CustomButton, 'Registrar');
+      await tester.tap(registerButton);
+      await tester.pump();
+
+      expect(find.text('Nome Inválido'), findsNothing);
+      expect(find.text('E-mail Inválido'), findsNothing);
+      expect(find.textContaining('A senha deve ter pelo menos'), findsNothing);
+      expect(find.text('Por favor, confirme sua senha'), findsNothing);
+      expect(find.text('As senhas não coincidem'), findsNothing);
+      // Assim como no login, não verificaremos a lógica de API, apenas validação.
+      // expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Adicionei novos testes de widget para as telas LoginScreen e RegisterScreen, localizadas em `test/screens/auth/`. Esses testes simulam interações suas, como inserir texto em campos e tocar em botões, para verificar a lógica de validação da interface.

Os testes cobrem cenários de:
- Campos de entrada vazios.
- Dados inválidos para nome, e-mail e senha.
- Senhas não coincidentes (na tela de registro).
- Dados válidos.

Uma correção foi aplicada em `test/screens/auth/login_screen_test.dart` para corresponder à mensagem de erro exata da validação de senha (incluindo um espaço no final).

Nota: Um teste preexistente em `test/screens/splash_screen_test.dart` continua falhando devido a um problema de Timer pendente.