### PR TITLE
Refactor: Otimiza e documenta ApiConfigService

### DIFF
--- a/lib/services/api_config_service.dart
+++ b/lib/services/api_config_service.dart
@@ -2,12 +2,17 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 import 'dart:async';
 
+/// Manages the configuration of the API base URL.
+/// It allows storing, retrieving, and automatically detecting the server URL.
 class ApiConfigService {
+  // Key used to store the API base URL in secure storage.
   static const String _storageKey = 'api_base_url';
+  // Default API URL, typically used for Android Emulator.
   static const String _defaultUrl = 'http://10.0.2.2:3000/api';
   final _storage = const FlutterSecureStorage();
 
-  // Lista de IPs comuns para testar
+  // List of common IP addresses for development environments and emulators.
+  // These are used as the initial set of IPs to test in `detectServerIp`.
   static const List<String> _commonIps = [
     '10.0.2.2', // Android Emulator
     'localhost',
@@ -19,25 +24,30 @@ class ApiConfigService {
   factory ApiConfigService() => _instance;
   ApiConfigService._internal();
 
-  // Getter para a URL base
+  /// Retrieves the stored API base URL.
+  /// Returns the default URL if no URL is stored.
   Future<String> getBaseUrl() async {
     final storedUrl = await _storage.read(key: _storageKey);
     return storedUrl ?? _defaultUrl;
   }
 
-  // Setter para atualizar a URL base
+  /// Sets and stores the new API base URL.
+  /// Performs validation and normalization:
+  /// - Ensures the URL starts with 'http://' or 'https://'.
+  /// - Removes a trailing slash if present.
+  /// - Appends '/api' if not present.
   Future<void> setBaseUrl(String newUrl) async {
-    // Validação básica da URL
+    // Basic URL validation.
     if (!newUrl.startsWith('http://') && !newUrl.startsWith('https://')) {
       throw Exception('URL inválida: deve começar com http:// ou https://');
     }
     
-    // Remove trailing slash se existir
+    // Remove trailing slash if it exists.
     if (newUrl.endsWith('/')) {
       newUrl = newUrl.substring(0, newUrl.length - 1);
     }
 
-    // Adiciona /api se não estiver presente
+    // Add /api suffix if not already present.
     if (!newUrl.endsWith('/api')) {
       newUrl = '$newUrl/api';
     }
@@ -45,27 +55,32 @@ class ApiConfigService {
     await _storage.write(key: _storageKey, value: newUrl);
   }
 
-  // Método para resetar para a URL padrão
+  /// Resets the API base URL to the default value (_defaultUrl).
+  /// This is typically the Android emulator's loopback address.
   Future<void> resetToDefault() async {
     await _storage.write(key: _storageKey, value: _defaultUrl);
   }
 
-  // Método para detectar automaticamente o IP do servidor
+  /// Attempts to automatically detect the server IP on the local network.
+  /// It tests a predefined list of common IPs by checking the `/api/health` endpoint.
+  ///
+  /// Note: Automatic IP detection has limitations and might not work reliably
+  /// across all network configurations. For greater reliability, especially in diverse
+  /// network environments, providing a manual URL configuration option for the user
+  /// within the application is recommended.
   Future<String?> detectServerIp() async {
-    // Lista de IPs para testar, incluindo IPs comuns de rede local
+    // List of IPs to test, including common local network IPs and gateways.
     final List<String> ipsToTest = [
       ..._commonIps,
-      // Adiciona IPs comuns de rede local (192.168.0.x e 192.168.1.x)
-      for (var i = 1; i <= 255; i++) ...[
-        '192.168.0.$i',
-        '192.168.1.$i',
-      ],
+      '192.168.1.1', // Common gateway
+      '192.168.0.1', // Another common gateway
     ];
 
-    // Timeout para cada tentativa
+    // Timeout for each connection attempt.
     const timeout = Duration(seconds: 1);
 
-    // Tenta cada IP em paralelo
+    // Try connecting to each IP in parallel.
+    // Uses the /api/health endpoint to verify server connectivity.
     final futures = ipsToTest.map((ip) async {
       try {
         final url = 'http://$ip:3000/api/health';


### PR DESCRIPTION
O serviço de configuração da API (`ApiConfigService`) foi refatorado para melhorar a eficiência da detecção de IP e a clareza do código.

Alterações principais:
- O método `detectServerIp` foi modificado para testar uma lista predefinida e menor de IPs comuns (incluindo IPs de emulador e gateways comuns), removendo a varredura exaustiva de sub-redes. Isso visa reduzir significativamente os atrasos que poderiam ocorrer durante a tentativa de detecção automática.
- A documentação agora também sugere a implementação de uma configuração manual de IP por você como a abordagem mais robusta para diferentes ambientes de rede.